### PR TITLE
Add cop for Hash default value initialization

### DIFF
--- a/lib/rubocop/cop/samesystem/hash_mutable.rb
+++ b/lib/rubocop/cop/samesystem/hash_mutable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Samesystem
+      # @example HashMutable: bar (default)
+      #   # Description of the `bar` style.
+      #
+      #   # bad
+      #   Hash.new({})
+      #
+      #   # bad
+      #   Hash.new([])
+      #
+      #   # good
+      #   Hash.new { |h, k| h[k] = {} }
+      #
+      #   # good
+      #   Hash.new { |h, k| h[k] = [] }
+      #
+      class HashMutable < Cop
+        include RuboCop::Cop::FrozenStringLiteral
+
+        def_node_matcher :hash_with_default?, <<~PATTERN
+          (send (const nil? :Hash) :new _)
+        PATTERN
+
+        def_node_matcher :string_type?, '(:str _)'
+
+        # @!method operation_produces_immutable_object?(node)
+        def_node_matcher :produces_immutable_object?, <<~PATTERN
+          {
+            (send {float int} {:+ :- :* :** :/ :% :<<} _)
+            (send !{(str _) array} {:+ :- :* :** :/ :%} {float int})
+            (send _ {:== :=== :!= :<= :>= :< :>} _)
+            (send _ {:count :length :size :to_i :to_f :freeze :deep_freeze} ...)
+            (block (send _ {:count :length :size} ...) ...)
+          }
+        PATTERN
+
+        UPCASE_CASE = /^[\dA-Z_]+[!?=]?$/.freeze
+
+        MSG = 'Ensure that default value of Hash returns immutable or a new object'
+
+        def on_send(node)
+          return unless hash_with_default?(node)
+
+          _receiver_node, _method_name, arg_node = *node
+          return if immutable_literal?(arg_node) || constant?(arg_node) || produces_immutable_object?(arg_node)
+
+          add_offense(node)
+        end
+
+        private
+
+        def immutable_literal?(node)
+          (frozen_string_literals_enabled? && string_type?(node)) || strip_parenthesis(node).immutable_literal?
+        end
+
+        def strip_parenthesis(node)
+          if node.begin_type? && node.children.first
+            node.children.first
+          else
+            node
+          end
+        end
+
+        # Implying that constant will always return .frozen => true
+        def constant?(node)
+          *_, last_node = *node
+
+          last_node.to_s.match?(UPCASE_CASE)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/samesystem_cops.rb
+++ b/lib/rubocop/cop/samesystem_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 require_relative 'samesystem/comment_format'
 require_relative 'samesystem/variable_naming'
+require_relative 'samesystem/hash_mutable'

--- a/spec/rubocop/cop/samesystem/hash_mutable_spec.rb
+++ b/spec/rubocop/cop/samesystem/hash_mutable_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Samesystem::HashMutable, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context 'with Numeric' do
+    context 'with float' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          foo = Hash.new(1.0)
+        RUBY
+      end
+    end
+
+    context 'with integer' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          foo = Hash.new(0)
+        RUBY
+      end
+    end
+  end
+
+  context 'with math operations' do
+    context 'when numeric' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          foo = Hash.new(5 + 4)
+        RUBY
+      end
+    end
+
+    context 'when not numeric' do
+      it 'does not register offense' do
+        expect_offense(<<~RUBY)
+          foo = Hash.new(5 + 4 + bar)
+                ^^^^^^^^^^^^^^^^^^^^^ Ensure that default value of Hash returns immutable or a new object
+        RUBY
+      end
+    end
+  end
+
+  context 'with methods that return Numeric' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = Hash.new([1, 2, 3].count)
+      RUBY
+    end
+
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = '0.0'.to_f
+      RUBY
+    end
+  end
+
+  context 'with symbol' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = Hash.new(:foo)
+      RUBY
+    end
+  end
+
+  context 'with constants' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = Hash.new(Math::PI)
+      RUBY
+    end
+
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = Hash.new(SameSystem::Calendar::Deep::VERY_SPECIAL_NUMBER)
+      RUBY
+    end
+  end
+
+  context 'when initializing default value using a block' do
+    it 'does not register offense' do
+      expect_no_offenses(<<~RUBY)
+        foo = Hash.new { |h, k| h[k] = {} }
+      RUBY
+    end
+  end
+
+  context 'with string' do
+    context 'when frozen_string_literal is enabled' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          # frozen_string_literal: true
+
+          foo = Hash.new('string')
+        RUBY
+      end
+    end
+
+    context 'when freezing string' do
+      it 'does not register offense' do
+        expect_no_offenses(<<~RUBY)
+          foo = Hash.new('string'.freeze)
+        RUBY
+      end
+    end
+
+    context 'when frozen_string_literal is not enabled' do
+      it 'registers offense when initializing hash' do
+        expect_offense(<<~RUBY)
+          foo = Hash.new('string')
+                ^^^^^^^^^^^^^^^^^^ Ensure that default value of Hash returns immutable or a new object
+        RUBY
+      end
+    end
+  end
+
+  context 'when initializing with potentially mutable object' do
+    it 'registers offense when initializing hash' do
+      expect_offense(<<~RUBY)
+        foo = Hash.new(bar)
+              ^^^^^^^^^^^^^ Ensure that default value of Hash returns immutable or a new object
+      RUBY
+    end
+
+    it 'registers offense when initializing hash' do
+      expect_offense(<<~RUBY)
+        foo = Hash.new([])
+              ^^^^^^^^^^^^ Ensure that default value of Hash returns immutable or a new object
+      RUBY
+    end
+
+    it 'registers offense when initializing hash' do
+      expect_offense(<<~RUBY)
+        foo = Hash.new({})
+              ^^^^^^^^^^^^ Ensure that default value of Hash returns immutable or a new object
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Add cop for checking whether hash default value is initialized with potentially mutable object.

I believe this cop will not result in false positives.

There could be false negatives though:
```
def bar
  5
end

Hash.new(bar)
``` 
This would raise cop warning even though when evaluating a method it would return immutable object.

AFAIK there is no way to validate that because parsed tree for this instance simply returns:
```
> ruby-parse -e "Hash.new(bar)"

(send
  (const nil :Hash) :new
  (send nil :bar))
```

These false negatives are a small price to pay considering the value that they add to ensuring that code working as expected.