### PR TITLE
Add rubocop for `travel_to` usage

### DIFF
--- a/lib/rubocop/cop/samesystem/travel_to_usage.rb
+++ b/lib/rubocop/cop/samesystem/travel_to_usage.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# TODO: when finished, run `rake generate_cops_documentation` to update the docs
+module RuboCop
+  module Cop
+    module Samesystem
+      # @example EnforcedStyle: single line comments
+      #   # Please begin your comments with capital letter if it begins with
+      #   # word character, leave single space after # and end your comments
+      #   # with period sign or other proper punctuation (?, !, ;).
+      #
+      #   # bad
+      #   travel_to(Date.current)
+      #
+      #   # good
+      #   travel_to(Date.current) { ... }
+      #
+      #   # good
+      #   travel_to(Date.current, &block)
+      #
+      class TravelToUsage < Cop
+        MSG = 'Provide block to avoid time leaks'
+
+        def on_send(node)
+          return unless node.method_name == :travel_to
+          return if contains_block?(node)
+
+          add_offense(node)
+        end
+
+        def contains_block?(node)
+          node.block_node || node.arguments.last&.block_pass_type?
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/samesystem_cops.rb
+++ b/lib/rubocop/cop/samesystem_cops.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 require_relative 'samesystem/comment_format'
-require_relative 'samesystem/variable_naming'
 require_relative 'samesystem/hash_mutable'
+require_relative 'samesystem/travel_to_usage'
+require_relative 'samesystem/variable_naming'

--- a/spec/lib/rubocop/cop/samesystem/travel_to_usage_spec.rb
+++ b/spec/lib/rubocop/cop/samesystem/travel_to_usage_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Samesystem::TravelToUsage do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  context 'when block is passed as argument is called with block' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Date.current, &example)
+      RUBY
+    end
+  end
+
+  context 'when block is passed as inline block (with curly brackets)' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Date.current) {}
+      RUBY
+    end
+  end
+
+  context 'when travel_to is called with block' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        travel_to(Date.current) do
+        end
+      RUBY
+    end
+  end
+
+  context 'when travel_to is called without block' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        before do
+          travel_to(Date.current)
+          ^^^^^^^^^^^^^^^^^^^^^^^ Provide block to avoid time leaks
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Does not allow to use `travel_to` without a block as this leaks into other rspec tests