### PR TITLE
Better handle DelegatePrivate cop inner class cases

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,19 @@
+name: Ruby
+on: [push, pull_request]
+jobs:
+  specs:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2']
+
+    runs-on: ubuntu-latest
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     rainbow (3.0.0)
+    rake (13.0.6)
     rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -53,6 +54,7 @@ PLATFORMS
 
 DEPENDENCIES
   pry-byebug
+  rake
   rspec
   rubocop-samesystem!
 

--- a/rubocop-samesystem.gemspec
+++ b/rubocop-samesystem.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rubocop'
+
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end
 

--- a/spec/lib/rubocop/cop/samesystem/delegate_private_spec.rb
+++ b/spec/lib/rubocop/cop/samesystem/delegate_private_spec.rb
@@ -3,10 +3,7 @@
 RSpec.describe RuboCop::Cop::Samesystem::DelegatePrivate do
   subject(:cop) { described_class.new(config) }
 
-  let(:config) { RuboCop::Config.new(cop_config) }
-  let(:cop_config) do
-    {}
-  end
+  let(:config) { RuboCop::Config.new({}) }
 
   context 'when no delegate is provided' do
     it 'registers no offense' do
@@ -73,6 +70,22 @@ RSpec.describe RuboCop::Cop::Samesystem::DelegatePrivate do
           end
 
           delegate :name, to: :user
+        end
+      RUBY
+    end
+  end
+
+  context 'when inner class is put in private scope and has delegate in public scope without "private: true"' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class User
+          private
+
+          class InnerUser
+            delegate :name, to: :user
+          end
+
+          delegate :foo, to: :bar, private: true
         end
       RUBY
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 require 'rubocop-samesystem'
 require 'rubocop/rspec/support'
-require 'pry-byebug'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
This PR fixes some DelegatePrivate cop edge cases related to inner private classes.

Before InnerUser delegate was marked as offense:
```ruby
class User
  private
  class InnerUser
    delegate :name, to: :user
  end
end
```