### PR TITLE
Make constant naming cop more dynamic

### DIFF
--- a/spec/lib/rubocop/cop/samesystem/constant_naming_spec.rb
+++ b/spec/lib/rubocop/cop/samesystem/constant_naming_spec.rb
@@ -7,13 +7,17 @@ RSpec.describe RuboCop::Cop::Samesystem::ConstantNaming do
   let(:cop_config) do
     {
       'Samesystem/ConstantNaming' => {
-        'PreferredNames' => preferred_names
+        'UndesirableNames' => undesirable_names_config
       }
     }
   end
 
-  let(:preferred_names) do
-    { 'BAD_NAME' => 'GOOD_NAME' }
+  let(:undesirable_names_config) do
+    {
+      'BAD_NAME' => {
+        'Message' => 'Use GOOD_NAME instead of BAD_NAME'
+      }
+    }
   end
 
   describe 'bad constant name' do
@@ -45,8 +49,12 @@ RSpec.describe RuboCop::Cop::Samesystem::ConstantNaming do
     end
 
     context 'when multiple bad constants are used' do
-      let(:preferred_names) do
-        { 'BAD_NAME' => 'GOOD_NAME', 'OTHER_BAD_CONSTANT' => 'GOOD_CONSTANT' }
+      let(:undesirable_names_config) do
+        super().merge(
+          'OTHER_BAD_CONSTANT' => {
+            'Message' => 'Use GOOD_CONSTANT instead of OTHER_BAD_CONSTANT'
+          }
+        )
       end
 
       it 'registers multiple offenses' do


### PR DESCRIPTION
Currently, the `Samesystem/ConstantNaming` cop allows defining a map of bad and preferred constant names. There are cases when some constants are not desired, but there is no easy alternative for replacement.

This PR changes the config structure for `Samesystem/ConstantNaming` that allows providing custom error messages instead of using fixed error messages.

before
```yaml
Samesystem/ConstantNaming:
  PreferredNames:
    Flipper: AppFeature
```

after
```yaml
Samesystem/ConstantNaming:
  UndesirableNames:
    Flipper:
      Message: 'Use AppFeature or ApplicationFeature instead'
```
