### PR TITLE
Fix DelegatePrivate when there is no code in file

### DIFF
--- a/lib/rubocop/cop/samesystem/delegate_private.rb
+++ b/lib/rubocop/cop/samesystem/delegate_private.rb
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def mark_scope(node)
-          return if node.receiver || !node.arguments.empty?
+          return if skip_node?(node)
 
           @private_ranges ||= []
 
@@ -58,6 +58,10 @@ module RuboCop
           elsif node.method?(:public)
             cut_from_private_range(scope_range)
           end
+        end
+
+        def skip_node?(node)
+          !node.parent || node.receiver || !node.arguments.empty?
         end
 
         def delegate_node?(node)

--- a/spec/lib/rubocop/cop/samesystem/delegate_private_spec.rb
+++ b/spec/lib/rubocop/cop/samesystem/delegate_private_spec.rb
@@ -5,6 +5,14 @@ RSpec.describe RuboCop::Cop::Samesystem::DelegatePrivate do
 
   let(:config) { RuboCop::Config.new({}) }
 
+  context 'without class' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        puts
+      RUBY
+    end
+  end
+
   context 'when no delegate is provided' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
This PR fixes `undefined method 'location' for nil:NilClass` for `DelegatePrivate` cop when there is only single method without arguments in file.